### PR TITLE
fix: check if env is mobile at sso token checking logic

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -53,6 +53,7 @@
         />
         <!-- Modal for Cross Browsing -->
         <recommended-browser-modal v-if="showsBrowserRecommendation()" />
+        <mobile-guide-modal v-if="$store.state.display.visibleMobileGuideModal" />
     </div>
 </template>
 
@@ -81,6 +82,7 @@ import GNB from '@/common/modules/navigations/gnb/GNB.vue';
 import TopNotification from '@/common/modules/portals/TopNotification.vue';
 
 
+import MobileGuideModal from '@/services/auth/reset-password/MobileGuideModal.vue';
 import { AUTH_ROUTE } from '@/services/auth/route-config';
 // import SurveyModal from '@/common/modules/survey/SurveyModal.vue';
 
@@ -88,6 +90,7 @@ import { AUTH_ROUTE } from '@/services/auth/route-config';
 export default defineComponent({
     name: 'App',
     components: {
+        MobileGuideModal,
         // SurveyModal,
         RecommendedBrowserModal,
         TopNotification,

--- a/src/lib/helper/cross-browsing-helper.ts
+++ b/src/lib/helper/cross-browsing-helper.ts
@@ -12,3 +12,15 @@ export const supportsBrowser = (): boolean => {
     const isDesktopChrome = agent.includes('chrome') && !isWhale && !isAndroid && !isIphone && !isOpera && !isBrave;
     return (isDesktopChrome || isEdge);
 };
+
+export const isMobile = () => {
+    const user = window.navigator.userAgent;
+    let is_mobile = false;
+
+    if (user.indexOf('iPhone') > -1
+        || user.indexOf('Android') > -1
+        || user.indexOf('iPad') > -1
+        || user.indexOf('iPod') > -1
+    ) is_mobile = true;
+    return is_mobile;
+};

--- a/src/lib/site-initializer/index.ts
+++ b/src/lib/site-initializer/index.ts
@@ -16,6 +16,7 @@ import { addAmchartsLicense, applyAmchartsGlobalSettings } from '@/lib/amcharts/
 import config from '@/lib/config';
 import { GTag } from '@/lib/gtag';
 import { Gtm } from '@/lib/gtm';
+import { isMobile } from '@/lib/helper/cross-browsing-helper';
 import { initRequestIdleCallback } from '@/lib/request-idle-callback-polyfill';
 import { initDayjs } from '@/lib/site-initializer/dayjs';
 
@@ -140,6 +141,10 @@ const checkSsoAccessToken = async () => {
     const ssoAccessToken = params.get('sso_access_token');
     // signOut
     if (ssoAccessToken) {
+        if (isMobile()) {
+            store.dispatch('display/showMobileGuideModal');
+            return;
+        }
         if (SpaceConnector.isTokenAlive) {
             try {
                 const authType = store.state.domain.extendedAuthType;

--- a/src/services/auth/reset-password/ResetPasswordPage.vue
+++ b/src/services/auth/reset-password/ResetPasswordPage.vue
@@ -58,7 +58,6 @@
                 {{ $t('AUTH.RESET_PASSWORD_PAGE.GO_TO_LOGIN_PAGE') }}
             </p-button>
         </div>
-        <mobile-guide-modal v-if="showMobileGuideModal" />
     </p-data-loader>
 </template>
 
@@ -85,7 +84,6 @@ import ErrorHandler from '@/common/composables/error/errorHandler';
 import { useFormValidator } from '@/common/composables/form-validator';
 
 import { getDefaultRouteAfterSignIn, getPasswordValidationInfo } from '@/services/auth/lib/helper';
-import MobileGuideModal from '@/services/auth/reset-password/MobileGuideModal.vue';
 import { AUTH_ROUTE } from '@/services/auth/route-config';
 
 
@@ -94,7 +92,6 @@ const UPDATE_PASSWORD_ACTION = 'UPDATE_PASSWORD';
 export default {
     name: 'ResetPasswordPage',
     components: {
-        MobileGuideModal,
         PFieldGroup,
         PTextInput,
         PButton,
@@ -109,7 +106,6 @@ export default {
             showResetPassword: false,
             isSessionExpired: computed(() => !!store.state.user.isSessionExpired),
             warningMessage: i18n.t('AUTH.RESET_PASSWORD_PAGE.INVALID_LINK'),
-            showMobileGuideModal: false,
         });
 
         const {
@@ -203,25 +199,8 @@ export default {
             await SpaceRouter.router.push({ name: AUTH_ROUTE.SIGN_OUT._NAME });
         };
 
-        /* util */
-        const isMobile = () => {
-            const user = navigator.userAgent;
-            let is_mobile = false;
-
-            if (user.indexOf('iPhone') > -1
-                || user.indexOf('Android') > -1
-                || user.indexOf('iPad') > -1
-                || user.indexOf('iPod') > -1
-            ) is_mobile = true;
-            return is_mobile;
-        };
         /* Init */
         (async () => {
-            if (isMobile()) {
-                state.showMobileGuideModal = true;
-                state.loading = false;
-                return;
-            }
             // When signed-in user needs to update password
             if (!state.isSessionExpired) {
                 if (store.state.user.requiredActions?.includes('UPDATE_PASSWORD')) {

--- a/src/store/modules/display/actions.ts
+++ b/src/store/modules/display/actions.ts
@@ -199,3 +199,7 @@ export const loadCurrencyRates: Action<DisplayState, any> = async ({
     commit('setCurrencyRates', rates);
     storeCurrencyRates(rates, dispatch);
 };
+
+export const showMobileGuideModal: Action<DisplayState, any> = ({ commit }) => {
+    commit('setVisibleMobileGuideModal', true);
+};

--- a/src/store/modules/display/index.ts
+++ b/src/store/modules/display/index.ts
@@ -24,6 +24,7 @@ const state: DisplayState = {
     isSignInFailed: storedDisplayState.isSignInFailed ?? false,
     currency: storedDisplayState.currency ?? 'USD',
     currencyRates: storedDisplayState.currencyRates ?? DEFAULT_CURRENCY_RATES,
+    visibleMobileGuideModal: false,
 };
 
 

--- a/src/store/modules/display/mutations.ts
+++ b/src/store/modules/display/mutations.ts
@@ -35,3 +35,7 @@ export const setCurrency: Mutation<DisplayState> = (state, currency: Currency): 
 export const setCurrencyRates: Mutation<DisplayState> = (state, rates: CurrencyRates): void => {
     state.currencyRates = rates;
 };
+
+export const setVisibleMobileGuideModal: Mutation<DisplayState> = (state, visibleMobileGuideModal: boolean): void => {
+    state.visibleMobileGuideModal = visibleMobileGuideModal;
+};

--- a/src/store/modules/display/type.ts
+++ b/src/store/modules/display/type.ts
@@ -27,6 +27,7 @@ export interface DisplayState {
     isSignInFailed: boolean;
     currency: Currency;
     currencyRates: CurrencyRates;
+    visibleMobileGuideModal: boolean;
 }
 
 export interface SidebarProps {


### PR DESCRIPTION
### To Reviewers
- [ ] Skip

### 작업 분류
- [ ] 신규 기능
- [ ] 버그 수정
- [ ] 기능 개선
- [x] 리팩토링 및 구조 변경
- [ ] 기타 (문서, CI/CD 워크플로 변경 등)

### 작업 내용
- mobile로 reset password 페이지 진입 시 알 수 없는 오류로 로그인 페이지로 튕기는 문제를 임시적으로 해결하기 위해 mobile guide modal 이 추가됨
- 리셋 패스워드 페이지를 진입하시 않는 문제로 추가된 것이므로, 리셋 패스워드 페이지를 보내기 전에 모달을 띄움.
- recommended browser modal 과 이중으로 뜰 우려가 있어, 분기처리 함

### 생각해볼 문제

